### PR TITLE
Support assertion rewriting and source code display

### DIFF
--- a/pytest_markdown/plugin.py
+++ b/pytest_markdown/plugin.py
@@ -1,15 +1,42 @@
-import imp
+import ast
+import types
+from linecache import cache
 
 import CommonMark
 import pytest
+from _pytest.assertion.rewrite import rewrite_asserts
 from _pytest.python import Module
+
+
+def create_pytest_module(name, path, source, config):
+    """Return a Module from source string with its assertions rewritten"""
+    try:
+        tree = ast.parse(source)
+    except SyntaxError:
+        return None
+
+    rewrite_asserts(tree, path, config)
+
+    try:
+        co = compile(tree, path, "exec", dont_inherit=True)
+    except SyntaxError:
+        return
+
+    mod = types.ModuleType(name)
+    exec(co, mod.__dict__)
+
+    # Also, seed the line cache, so pytest can show source code
+    def getsource():
+        return source
+    cache[path] = (getsource,)
+
+    return mod
 
 
 class MarkdownItem(Module):
 
-    def __init__(self, name, file, code, nodeid=None):
-        self._code_obj = imp.new_module(name)
-        exec(code, self._code_obj.__dict__)
+    def __init__(self, name, file, code, nodeid=None, config=None):
+        self._code_obj = create_pytest_module(name, file.name, code, config)
         super().__init__(name, file, nodeid=nodeid)
 
     def _getobj(self):
@@ -88,10 +115,11 @@ class MarkdownCollector(object):
             nodeid = self.stack[-1][1].nodeid + '::' + name
 
         mi = MarkdownItem(
-            name,
-            self.stack[-1][1],
-            output,
-            nodeid=nodeid
+            name=name,
+            file=self.stack[-1][1],
+            code=output,
+            nodeid=nodeid,
+            config=self.item.config,
         )
         self.collected.append(mi)
 


### PR DESCRIPTION
This changes how the modules get created, so pytest can show source code and intermediate assertion values during error reporting:

```
_________________________________ test_the_namerator _________________________________

full_name = 'John Jacob last'

    def test_the_namerator(full_name):
>       assert full_name == 'John Jacob Jingleheimer-Schmidt'
E       AssertionError: assert 'John Jacob last' == 'John Jacob Jingleheimer-Schmidt'
E         - John Jacob last
E         + John Jacob Jingleheimer-Schmidt

quickstart:13: AssertionError
============================== 1 failed in 0.04 seconds ==============================
```


Previously:
```
_________________________________ test_the_namerator _________________________________

full_name = 'John Jacob last'

>   ???
E   AssertionError

<string>:13: AssertionError
============================== 1 failed in 0.07 seconds ==============================
```